### PR TITLE
불필요한 아이콘 임포트 문 제거.

### DIFF
--- a/src/domain/setting/containers/BackgroundContainer.jsx
+++ b/src/domain/setting/containers/BackgroundContainer.jsx
@@ -13,7 +13,6 @@ import {
   setImageScale,
 } from 'slice';
 
-import { ControlPointSharp } from '@material-ui/icons';
 import {
   ColorpickerIcon,
   AlphaPickerIcon,


### PR DESCRIPTION
사용하지 않고 있기 때문에 제거했습니다.
`import { ControlPointSharp } from '@material-ui/icons';`