### PR TITLE
BannerMakerHeader 컴포넌트에 대한 테스트 작성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1906,9 +1906,9 @@
       }
     },
     "@testing-library/jest-dom": {
-      "version": "5.11.9",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.9.tgz",
-      "integrity": "sha512-Mn2gnA9d1wStlAIT2NU8J15LNob0YFBVjs2aEQ3j8rsfRQo+lAs7/ui1i2TGaJjapLmuNPLTsrm+nPjmZDwpcQ==",
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.14.1.tgz",
+      "integrity": "sha512-dfB7HVIgTNCxH22M1+KU6viG5of2ldoA5ly8Ar8xkezKHKXjRvznCdbMbqjYGgO2xjRbwnR+rR8MLUIqF3kKbQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2",
@@ -1917,6 +1917,7 @@
         "chalk": "^3.0.0",
         "css": "^3.0.0",
         "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
         "lodash": "^4.17.15",
         "redent": "^3.0.0"
       },
@@ -1953,6 +1954,12 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "dom-accessibility-api": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz",
+          "integrity": "sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw==",
           "dev": true
         },
         "has-flag": {
@@ -2176,9 +2183,9 @@
       "dev": true
     },
     "@types/testing-library__jest-dom": {
-      "version": "5.9.5",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz",
-      "integrity": "sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==",
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.1.tgz",
+      "integrity": "sha512-Gk9vaXfbzc5zCXI9eYE9BI5BNHEp4D3FWjgqBE/ePGYElLAP+KvxBcsdkwfIVvezs605oiyd/VrpiHe3Oeg+Aw==",
       "dev": true,
       "requires": {
         "@types/jest": "*"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-react": "^7.12.10",
-    "@testing-library/jest-dom": "^5.11.9",
+    "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.3",
     "@types/jest": "^26.0.19",
     "babel-jest": "^26.6.3",

--- a/src/domain/BannerMakerHeader.test.jsx
+++ b/src/domain/BannerMakerHeader.test.jsx
@@ -5,10 +5,33 @@ import { render } from '@testing-library/react';
 import BannerMakerHeader from './BannerMakerHeader';
 
 describe('BannerMakerHeader', () => {
-  it('renders app title', () => {
-    const { container } = render(<BannerMakerHeader />);
+  function renderHeader({ theme }) {
+    return render((
+      <BannerMakerHeader theme={theme} />
+    ));
+  }
 
-    expect(container).toHaveTextContent(/Banner\+/);
-    expect(container).toHaveTextContent(/Settings/);
+  const alt = 'iBanner Logo';
+  const lightThemeLogo = '/image/iBanner_logo_black.png';
+  const darkThemeLogo = '/image/iBanner_logo_white.png';
+
+  context('when light theme', () => {
+    it('it renders light logo', () => {
+      const { getByRole } = renderHeader({ theme: 'light' });
+
+      const logo = getByRole('img');
+      expect(logo).toHaveAttribute('alt', alt);
+      expect(logo).toHaveAttribute('src', lightThemeLogo);
+    });
+  });
+
+  context('when dark theme', () => {
+    it('it renders dark logo', () => {
+      const { getByRole } = renderHeader({ theme: 'dark' });
+
+      const logo = getByRole('img');
+      expect(logo).toHaveAttribute('alt', alt);
+      expect(logo).toHaveAttribute('src', darkThemeLogo);
+    });
   });
 });


### PR DESCRIPTION
## BannerMakerHeader 테스트 작성

- `npm install --save-dev @testing-library/jest-dom` 설치.

- 테스트 대상
  - 컴포넌트 정상적 렌더링 테스트.
  - 라이트/다크 모드별 로고 정상적 렌더링 테스트.