### PR TITLE
JEST Coverage 스크립트 명령어 추가.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest --watchAll --modulePaths=src",
     "testf": "jest --watchAll --modulePaths=src -- $FILE",
+    "coverage": "jest --coverage",
     "start": "webpack-dev-server --mode development --open --hot",
     "build": "webpack --mode production"
   },


### PR DESCRIPTION
## NPM Scripts 명령어 추가.

테스트 커리리지를 확인하기 위해 NPM SCRIPTS에 `"coverage": "jest --coverage"`를 추가했습니다.
테스트 커버리지 100%를 최대한 목표로 테스크 코드를 열심히 작성하고자 합니다.