### PR TITLE
글자 크기 변경 슬라이더 onChange 버그 수정

### DIFF
--- a/src/domain/preview/components/layers/text/CustomText.jsx
+++ b/src/domain/preview/components/layers/text/CustomText.jsx
@@ -85,8 +85,8 @@ export default function CustomText({
         draggable={!isCentered}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        onClick={handleClick}
-        onTap={handleClick}
+        onClick={(event) => handleClick(event)}
+        onTap={(event) => handleClick(event)}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
         onTouchStart={handleDragStart}

--- a/src/domain/setting/components/text/FontSize.jsx
+++ b/src/domain/setting/components/text/FontSize.jsx
@@ -128,7 +128,7 @@ const FontSize = ({ defaultValue, onChange }) => {
             key={`slider-${defaultValue}`}
             defaultValue={Number(defaultValue)}
             marks={marks}
-            onChangeCompleteted={handleChange}
+            onChangeCommitted={handleChange}
           />
         </Grid>
         <Grid item>


### PR DESCRIPTION
`onChangeCompleteted`에서 `onChangeCommitted`로 onChange 핸들러 수정했습니다.
버전 호환 진행하면서 변경된 것으로 보입니다.