### PR TITLE
텍스트 클릭시 버블링 현상 제거

### DIFF
--- a/src/domain/preview/PreviewContainer.jsx
+++ b/src/domain/preview/PreviewContainer.jsx
@@ -49,7 +49,8 @@ const PreviewKonva = ({ canvasRef }) => {
     dispatch(setTextPosition({ texts: newTexts }));
   }, []);
 
-  function handClickStage() {
+  function handClickStage(e) {
+    e.evt.stopPropagation();
     dispatch(setSelectedTextId(null));
   }
 

--- a/src/domain/preview/components/layers/text/CustomText.jsx
+++ b/src/domain/preview/components/layers/text/CustomText.jsx
@@ -45,9 +45,9 @@ export default function CustomText({
     transformerCanvas.getLayer().batchDraw();
   });
 
-  function handleClick(event) {
+  function handleClick(e) {
+    e.cancelBubble = true;
     onSelect(id);
-    event.preventDefault();
   }
 
   function handleMouseEnter() {
@@ -85,8 +85,8 @@ export default function CustomText({
         draggable={!isCentered}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        onClick={(event) => handleClick(event)}
-        onTap={(event) => handleClick(event)}
+        onClick={handleClick}
+        onTap={handleClick}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
         onTouchStart={handleDragStart}


### PR DESCRIPTION
## 텍스트 클릭에 따른 버블링 현상 제거

`e.cancelBubble = true;` 옵션을 통해서 이벤트 버블링 현상 제거했습니다.

버블링을 제어하지 않으면 `Stage` onClick 이벤트가 맨 마지막에 실행되므로, 텍스트가 선택되지 않는 현상이 발생했습니다.

이 이슈를 해결하기 위해 `e.cancelBubble = true;` 옵션을 추가했습니다.

(refector/text-onclick-handler-bug-fixed)
