### PR TITLE
배너 크기 변경 시, 그리드 라인 덜 채워지는 현상 수정

### DIFF
--- a/src/domain/preview/components/layers/helper/GridHelperLayer.jsx
+++ b/src/domain/preview/components/layers/helper/GridHelperLayer.jsx
@@ -11,8 +11,8 @@ export default function GridHelperLayer({
 }) {
   const padding = blockSnapSize;
 
-  const rowCount = Math.ceil(width / padding);
-  const colCount = Math.ceil(height / padding);
+  const rowCount = Math.ceil(height / padding);
+  const colCount = Math.ceil(width / padding);
 
   const halfRowCount = Math.ceil(rowCount / 2);
   const halfColCount = Math.ceil(colCount / 2);
@@ -25,9 +25,9 @@ export default function GridHelperLayer({
           key={i}
           points={[
             0,
-            Math.round(-i * padding) + 250,
+            Math.round(-i * padding) + height / 2,
             width,
-            Math.round(-i * padding) + 250,
+            Math.round(-i * padding) + height / 2,
           ]}
           strokeWidth={0.5}
         />
@@ -37,9 +37,9 @@ export default function GridHelperLayer({
           key={i}
           points={[
             0,
-            Math.round((i + 1) * padding) + 250,
+            Math.round((i + 1) * padding) + height / 2,
             width,
-            Math.round((i + 1) * padding) + 250,
+            Math.round((i + 1) * padding) + height / 2,
           ]}
           strokeWidth={0.5}
         />
@@ -49,9 +49,9 @@ export default function GridHelperLayer({
         <GridLine
           key={i}
           points={[
-            Math.round(-i * padding) + 250,
+            Math.round(-i * padding) + width / 2,
             0,
-            Math.round(-i * padding) + 250,
+            Math.round(-i * padding) + width / 2,
             height,
           ]}
           strokeWidth={0.5}
@@ -61,9 +61,9 @@ export default function GridHelperLayer({
         <GridLine
           key={i}
           points={[
-            Math.round((i + 1) * padding) + 250,
+            Math.round((i + 1) * padding) + width / 2,
             0,
-            Math.round((i + 1) * padding) + 250,
+            Math.round((i + 1) * padding) + width / 2,
             height,
           ]}
           strokeWidth={0.5}


### PR DESCRIPTION
## 그리드 라인 덜 채워지는 이슈 수정

배너 가로/세로 변경시에도 정상적으로 그리드 라인 생기도록 수정 완료했습니다.
가로줄/세로줄에 대한 연산이 반대로 되어있던 것이 원인이었습니다.