### PR TITLE
## 채도명암비에 따른 텍스트 그리드 라인 색상 변경

### DIFF
--- a/src/domain/preview/PreviewContainer.jsx
+++ b/src/domain/preview/PreviewContainer.jsx
@@ -88,6 +88,7 @@ const PreviewKonva = ({ canvasRef }) => {
           <MemoizedGridHelperLayer
             width={width}
             height={height}
+            backgroundColor={layerColor}
           />
         )
         : null}

--- a/src/domain/preview/components/layers/helper/GridHelperLayer.jsx
+++ b/src/domain/preview/components/layers/helper/GridHelperLayer.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 
 import { Layer } from 'react-konva';
 
+import { rgb2hex, choiceColorByBackgroundColor } from 'utils';
 import GridLine from './GridLine';
 
 export default function GridHelperLayer({
   width,
   height,
+  backgroundColor,
   blockSnapSize = 30,
 }) {
   const padding = blockSnapSize;
@@ -16,6 +18,14 @@ export default function GridHelperLayer({
 
   const halfRowCount = Math.ceil(rowCount / 2);
   const halfColCount = Math.ceil(colCount / 2);
+
+  const hexBackgroundColor = rgb2hex({ ...backgroundColor });
+
+  const stroke = choiceColorByBackgroundColor({
+    hexColor: hexBackgroundColor,
+    hexColorWhenLight: '#888',
+    hexColorWhenDark: '#fff',
+  });
 
   return (
     <Layer>
@@ -29,7 +39,8 @@ export default function GridHelperLayer({
             width,
             Math.round(-i * padding) + height / 2,
           ]}
-          strokeWidth={0.5}
+          stroke={stroke}
+          strokeWidth={0.4}
         />
       ))}
       {Array.from(Array(halfRowCount), (e, i) => (
@@ -41,7 +52,8 @@ export default function GridHelperLayer({
             width,
             Math.round((i + 1) * padding) + height / 2,
           ]}
-          strokeWidth={0.5}
+          stroke={stroke}
+          strokeWidth={0.4}
         />
       ))}
       {/* 세로 줄 */}
@@ -54,7 +66,8 @@ export default function GridHelperLayer({
             Math.round(-i * padding) + width / 2,
             height,
           ]}
-          strokeWidth={0.5}
+          stroke={stroke}
+          strokeWidth={0.4}
         />
       ))}
       {Array.from(Array(halfColCount), (e, i) => (
@@ -66,7 +79,8 @@ export default function GridHelperLayer({
             Math.round((i + 1) * padding) + width / 2,
             height,
           ]}
-          strokeWidth={0.5}
+          stroke={stroke}
+          strokeWidth={0.4}
         />
       ))}
     </Layer>

--- a/src/utils.js
+++ b/src/utils.js
@@ -57,8 +57,8 @@ export function hex2rgb(hex) {
   };
 }
 
-export function choiceColorByBackgroundColor({ hexColor, lightHexColor, darkHexColor }) {
+export function choiceColorByBackgroundColor({ hexColor, hexColorWhenLight, hexColorWhenDark }) {
   const { r, g, b } = hex2rgb(hexColor);
-  const luma = 0.2126 * r + 0.7152 * g + 0.0722 * b; // per ITU-R BT.709
-  return luma < 127.5 ? lightHexColor : darkHexColor;
+  const luma = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  return luma > 127.5 ? hexColorWhenLight : hexColorWhenDark;
 }


### PR DESCRIPTION
## 라이트모드 다크모드 텍스트 그리드 라인 

채도가 높거나, 명도가 높을 때, 그리드 라인이 잘 보이지 않는 이슈가 있습니다.

이를 개선하기 위해서 채도 및 명도에 따라 다른 색상에 그리드 라인이 보이도록 변경했습니다.

100% 만족할만한 개선은 되지 않았습니다.
(feature/helper grid line light dark color added)
