### PR TITLE
이미지 드래그 앤 드랍 설정 추가

### DIFF
--- a/src/domain/preview/components/layers/image/ImageLayer.jsx
+++ b/src/domain/preview/components/layers/image/ImageLayer.jsx
@@ -29,6 +29,26 @@ export default function ImageLayer({
     imageScale: scale.y,
   });
 
+  function handleClick(e) {
+    e.cancelBubble = true;
+  }
+
+  function handleMouseEnter() {
+    document.body.style.cursor = 'grab';
+  }
+
+  function handleMouseLeave() {
+    document.body.style.cursor = 'default';
+  }
+
+  function handleDragStart() {
+    document.body.style.cursor = 'grabbing';
+  }
+
+  function handleDragEnd() {
+    document.body.style.cursor = 'grab';
+  }
+
   return (
     <Layer>
       <Image
@@ -36,6 +56,15 @@ export default function ImageLayer({
         scale={scale}
         x={pointX}
         y={pointY}
+        draggable
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onClick={handleClick}
+        onTap={handleClick}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onTouchStart={handleDragStart}
+        onTouchEnd={handleDragEnd}
       />
     </Layer>
   );

--- a/src/domain/preview/components/layers/text/CustomText.jsx
+++ b/src/domain/preview/components/layers/text/CustomText.jsx
@@ -68,7 +68,7 @@ export default function CustomText({
   }
 
   function handleDragEnd() {
-    document.body.style.cursor = 'grabbing';
+    document.body.style.cursor = 'grab';
   }
 
   return (


### PR DESCRIPTION
이미지 추가시, 드래그 앤 드랍이 가능하도록 `draggable` 설정을 추가했습니다.
다만, 다시 그려질 때, 중앙으로 배치되는 이슈가 텍스트와 동일하게 발생합니다.
