### PR TITLE
폰트 스타일 셀렉트 박스에 대해 옵션별 해당하는 옵션의 글꼴 적용

### DIFF
--- a/src/domain/setting/components/text/FontFamily.jsx
+++ b/src/domain/setting/components/text/FontFamily.jsx
@@ -90,6 +90,7 @@ const FontFamily = ({ defaultValue, onChange }) => {
                 <option
                   key={font}
                   value={font}
+                  style={{ fontFamily: `${font}` }}
                 >
                   {fontName}
                 </option>

--- a/src/domain/setting/containers/TextInputContainer.jsx
+++ b/src/domain/setting/containers/TextInputContainer.jsx
@@ -76,6 +76,7 @@ export default function TextInputContainer() {
         label="제목"
         value={contentProperties.content}
         onChange={handleChange}
+        inputProps={{ style: { fontFamily: `${contentProperties.fontFamily}` } }}
         rowsMax={3.4}
         variant="outlined"
         multiline


### PR DESCRIPTION
## 글꼴 선택 박스의 옵션별 해당 글꼴 출력

`option`에 `fontFamily` 스타일을 추가하여, 옵션에 해당하는 글꼴을 사용자에게 보이도록 변경했습니다.
(feature/banner text with font family applied)
